### PR TITLE
Add windows XP support

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,15 @@ module.exports = function whereis(name, cb) {
         if (error || stderr || stdout === '' || stdout.indexOf( '/' ) === -1) {
           cp.exec('where ' + name, function (error, stdout, stderr) { //windows
             if (error || stderr || stdout === '' || stdout.indexOf('\\') === -1) {
-              return cb(new Error('Could not find ' + name + ' on your system'));
+              cp.exec('for %i in (' + name + '.exe) do @echo. %~$PATH:i', function (error, stdout, stderr) { //windows xp
+                if (error || stderr || stdout === '' || stdout.indexOf('\\') === -1) {
+                  return cb(new Error('Could not find ' + name + ' on your system'));
+                }
+                return cb(null, stdout);
+              });
+            } else {
+              return cb(null, stdout);
             }
-            return cb(null, stdout);
           });
         }
         else {
@@ -23,4 +29,3 @@ module.exports = function whereis(name, cb) {
     }
   });
 };
-


### PR DESCRIPTION
I was trying to use "selenium-standalone" (cool project !!) in windows xp environment but it fails with error like "could not find java... ", but java was correctly installed. So following the code I found that there is an issue with the "whereis" module because "where" command is not valid in windows xp.
